### PR TITLE
docs: update for new new extension listing guidelines/fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,19 @@
 {
   "name": "datadog-metrics",
-  "title": "Datadog metrics",
-  "description": "Allows jumps to the Datadog page for a metrics/instrumentation call in the code files",
+  "description": "Jump to Datadog metrics from statsd calls in code",
   "publisher": "sourcegraph",
   "repository": {
     "type": "git",
     "url": "https://github.com/sourcegraph/sourcegraph-datadog-metrics"
   },
+  "categories": [
+    "External services"
+  ],
+  "tags": [
+    "datadog",
+    "metrics",
+    "statsd"
+  ],
   "activationEvents": [
     "*"
   ],


### PR DESCRIPTION
Updates to reflect the changes to extension listings on the extension registry in https://github.com/sourcegraph/sourcegraph/pull/1612 and https://github.com/sourcegraph/sourcegraph/pull/1613:

- Extensions can have tags and categories.
- Extensions no longer have titles. The extension ID and the extension description are the only things shown now.
- The extension description can/should be shorter now that it's shown on 1 line and there is no title.

https://github.com/sourcegraph/sourcegraph/issues/1906