### PR TITLE
remove mention of this extension working on code hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,8 @@ Works on [Sourcegraph.com](https://sourcegraph.com), [self-hosted Sourcegraph in
 
 ## Usage
 
-**Note:** Using this extension on private code in the [Sourcegraph browser extension](https://docs.sourcegraph.com/integration/browser_extension) requires a [self-hosted Sourcegraph instance](https://docs.sourcegraph.com/#quickstart) (because it needs access to the contents of the current file).
-
 1. Enable the `sourcegraph-datadog-metrics` extension:
    - On Sourcegraph.com, visit [https://sourcegraph.com/extensions/sourcegraph/datadog-metrics](https://sourcegraph.com/extensions/sourcegraph/datadog-metrics) to enable it.
    - On a self-hosted Sourcegraph instance, select **User menu > Extensions**, search for `sourcegraph/datadog-metrics`, and enable it.
 2. Visit any code file containing datadog statsd metric/instrumentation calls on Sourcegraph.
 3. Click on the Datadog link that appears at the end of the line of each Datadog metric/instrumentation call to open the associated graph in the Datadog page.
-
-### On your code host
-
-This extension adds the same features to code containing Datadog statsd code on your code host if you're using the [Sourcegraph browser extension](https://docs.sourcegraph.com/integration/browser_extension). To use it on your code host:
-
-1. Follow the [usage steps](#usage) above to enable this `sourcegraph/datadog-metrics` extension.
-1. Install the [Sourcegraph browser extension](https://docs.sourcegraph.com/integration/browser_extension).
-   - If you're using it with a self-hosted Sourcegraph instance, enter the Sourcegraph instance URL into the Sourcegraph browser extension options menu. Then click the gear icon and enable *Experimental features: Use extensions*.
-1. Visit files containing Datadog statsd code on your code host and click on the links rendered behind each Datadog statsd code that will send you to your Datadog account and show the graph of the metrics that this code generates.
-
-![screenshot of using datadog-extension on GitHub](https://d2ddoduugvun08.cloudfront.net/items/01153p453B2H0x020t1c/Image%202019-01-14%20at%2012.40.48%20AM.png?X-CloudApp-Visitor-Id=2879273)


### PR DESCRIPTION
`TextDocument#text` is `undefined` on code hosts, due to https://github.com/sourcegraph/sourcegraph/pull/2051. This means that extensions needing that value only work on Sourcegraph.

We intend to re-add the ability for this extension to work on code hosts.

cc @felixfbecker @lguychard